### PR TITLE
Popularity score fix

### DIFF
--- a/lib/analyze/collect/npm.js
+++ b/lib/analyze/collect/npm.js
@@ -92,7 +92,7 @@ function fetchDependentsCount(name, npmNano) {
  *
  * @param {object} data The module data
  *
- * @return {Number} The number of stars
+ * @return {number} The number of stars
  */
 function extractStarsCount(data) {
     // The users that starred are stored in the module data itself under the `users` property

--- a/lib/scoring/aggregate.js
+++ b/lib/scoring/aggregate.js
@@ -24,9 +24,8 @@ function calculateAggregation(evaluations) {
     const accumulator = mapValues(shape, (value, key) => {
         return evaluations
         .map((evaluation) => objGet(evaluation, key))
-        // DownloadAcceleration is the only with negative values
-        // And all the packages with negative values will have a score of 0
-        // So, we must remove all negative values from aggregation in order to have a better score curve
+        // All the packages with negative values will have a score of 0 (e.g.: downloads acceleration)
+        // So, we must remove all negative values from the aggregation in order to have a better score curve
         .filter((evaluation) => evaluation >= 0)
         .sort((a, b) => a - b);
     });

--- a/lib/scoring/aggregate.js
+++ b/lib/scoring/aggregate.js
@@ -24,6 +24,10 @@ function calculateAggregation(evaluations) {
     const accumulator = mapValues(shape, (value, key) => {
         return evaluations
         .map((evaluation) => objGet(evaluation, key))
+        // DownloadAcceleration is the only with negative values
+        // And all the packages with negative values will have a score of 0
+        // So, we must remove all negative values from aggregation in order to have a better score curve
+        .filter((evaluation) => evaluation >= 0)
         .sort((a, b) => a - b);
     });
 

--- a/lib/scoring/score.js
+++ b/lib/scoring/score.js
@@ -90,7 +90,9 @@ function scorePopularity(popularity, aggregation) {
     const scores = {
         communityInterest: calculateScore(popularity.communityInterest, aggregation.communityInterest),
         downloadsCount: calculateScore(popularity.downloadsCount, aggregation.downloadsCount),
-        downloadsAcceleration: calculateScore(popularity.downloadsAcceleration, aggregation.downloadsAcceleration),
+        downloadsAcceleration: popularity.downloadsAcceleration > 0 ?
+            calculateScore(popularity.downloadsAcceleration, aggregation.downloadsAcceleration) :
+            0,
         dependentsCount: calculateScore(popularity.dependentsCount, aggregation.dependentsCount),
     };
 

--- a/lib/scoring/score.js
+++ b/lib/scoring/score.js
@@ -21,6 +21,10 @@ const log = logger.child({ module: 'scoring/score' });
  * @return {number} The score
  */
 function calculateScore(value, aggregation) {
+    if (value <= 0) {
+        return 0;
+    }
+
     const normValue = clamp((value - aggregation.min) / aggregation.max, 0, 1);
     const normAvg = clamp((aggregation.truncatedMean - aggregation.min) / aggregation.max, 0, 1);
     const roots = solveCubic(-3 * normAvg, 3 * normAvg, -1 * normValue);
@@ -90,9 +94,7 @@ function scorePopularity(popularity, aggregation) {
     const scores = {
         communityInterest: calculateScore(popularity.communityInterest, aggregation.communityInterest),
         downloadsCount: calculateScore(popularity.downloadsCount, aggregation.downloadsCount),
-        downloadsAcceleration: popularity.downloadsAcceleration > 0 ?
-            calculateScore(popularity.downloadsAcceleration, aggregation.downloadsAcceleration) :
-            0,
+        downloadsAcceleration: calculateScore(popularity.downloadsAcceleration, aggregation.downloadsAcceleration),
         dependentsCount: calculateScore(popularity.dependentsCount, aggregation.dependentsCount),
     };
 

--- a/lib/scoring/util/solveCubic.js
+++ b/lib/scoring/util/solveCubic.js
@@ -1,10 +1,11 @@
 'use strict';
+
 const Big = require('bignumber.js');
 
 /**
  * Calculate the cubic root of the given number
  *
- * @param {number} x The value
+ * @param {BigNumber} x The value
  *
  * @return {number} The cubic root
  */

--- a/lib/scoring/util/solveCubic.js
+++ b/lib/scoring/util/solveCubic.js
@@ -4,16 +4,14 @@ const Big = require('bignumber.js');
 /**
  * Calculate the cubic root of the given number
  *
- * @param {number|BigNumber} x The value
+ * @param {number} x The value
  *
  * @return {number} The cubic root
  */
 function cubeRoot(x) {
-    x = x instanceof Big ? Number(x.valueOf()) : x;
+    const root = Math.pow(x.abs().valueOf(), 1 / 3);
 
-    const root = Math.pow(Math.abs(x), 1 / 3);
-
-    return x < 0 ? -root : root;
+    return new Big(x.lt(0) ? -root : root);
 }
 
 /**
@@ -21,38 +19,47 @@ function cubeRoot(x) {
  * Based on: http://stackoverflow.com/a/27176424
  * Assumes a = 1
  *
- * @param {Number} b Value multiplied to x^2
- * @param {Number} c Value multiplied to x
- * @param {Number} d Constant Value
+ * @param {number} b Value multiplied to x^2
+ * @param {number} c Value multiplied to x
+ * @param {number} d Constant Value
  *
  * @return {array} Array of roots
  */
 function solveCubic(b, c, d) {
     // Convert to depressed cubic t^3+pt+q = 0 (subst x = t - b/3a)
-    const p = (3 * c - Math.pow(b, 2)) / 3;
-    const q = (2 * Math.pow(b, 3) - 9 * b * c + 27 * d) / 27;
+    b = new Big(b);
+    c = new Big(c);
+    d = new Big(d);
+
+    // (3 * c - b * b) / (3 * a * a)
+    const p = (c.times(3).minus(b.pow(2))).div(3);
+    // (2 * b * b * b - 9 * a * b * c + 27 * a * a * d) / (27 * a * a * a)
+    const q = (b.pow(3).times(2)
+        .minus(b.times(c).times(9))
+        .plus(d.times(27)))
+        .div(27);
     let roots;
 
-    if (Math.abs(p) < 1e-11) { // p = 0 -> t^3 = -q -> t = -q^1/3
+    if (p.abs().lt(0)) { // p = 0 -> t^3 = -q -> t = -q^1/3
         roots = [cubeRoot(-q)];
-    } else if (Math.abs(q) < 1e-11) { // q = 0 -> t^3 + pt = 0 -> t(t^2+p)=0
-        const res = Math.sqrt(-p);
+    } else if (q.abs().lt(0)) { // q = 0 -> t^3 + pt = 0 -> t(t^2+p)=0
+        const res = p.times(-1).sqrt();
 
-        roots = [0].concat(p < 1e-11 ? [res, -res] : []);
+        roots = [new Big(0)].concat(p.lt(0) ? [res, res.times(-1)] : []);
     } else {
-        const D = q * q / 4 + Math.pow(p, 3) / 27;
+        const D = q.pow(2).div(4).plus(p.pow(3).div(27));
 
-        if (Math.abs(D) < 1e-11) { // D = 0 -> two roots
-            const r = q / p;
+        if (D.abs().lt(0)) { // D = 0 -> two roots
+            const r = q.div(p);
 
-            roots = [-1.5 * r, 3 * r];
-        } else if (Math.abs(D) > 0) { // Only one real root
-            const u = cubeRoot(-q / 2 - Math.sqrt(D));
+            roots = [r.times(-1.5), r.times(3)];
+        } else if (D.gt(0)) { // Only one real root
+            const u = cubeRoot(q.times(-1).div(2).minus(D.sqrt()));
 
-            roots = [u - (p / (3 * u))];
+            roots = [u.minus(p.div(u.times(3)))];
         } else {  // D < 0, three roots, but needs to use complex numbers/trigonometric solution
-            const u = new Big(p).times(-3).sqrt().times(2);
-            const t = new Big(Math.acos(new Big(q * 3).div(u.mul(p)).valueOf())).div(3); // D < 0 implies p < 0 and acos argument in [-1..1]
+            const u = p.times(-3).sqrt().times(2);
+            const t = new Big(Math.acos(q.times(3).div(p.mul(u)).valueOf())).div(3); // D < 0 implies p < 0 and acos argument in [-1..1]
             const k = new Big(2 / 3 * Math.PI);
 
             roots = [
@@ -65,10 +72,10 @@ function solveCubic(b, c, d) {
 
     // Convert back from depressed cubic
 
-    const B = b / 3;
+    const B = b.div(3);
 
     for (let i = 0; i < roots.length; i += 1) {
-        roots[i] = roots[i] - B;
+        roots[i] = roots[i].minus(B).valueOf();
     }
 
     return roots;


### PR DESCRIPTION
This [tweet](https://twitter.com/bfred_it/status/744175235637731328) and comparing those two modules with `jaydata-core` intrigued me and @satazor. And we found out that some modules were wrongly scored because of some imprecision associated with solving cubic roots. 

Changed it to use bignumber.js. Performance optimizations may be possible, but for now the goal was to make sure the calculated values are correct.

Other issue that was found is that even with negative downloads acceleration, packages were scored 0.75 and sometimes it was contributing to an higher popularity score...

Now all packages with a negative download acceleration receive a 0 score on this. [See](https://github.com/npms-io/npms-analyzer/blob/c825e72d71e38129e4269d979ae2277b687d5d0d/lib/scoring/score.js#L24)

With these changes `jaydata-core` popularity changed from 0.35 to 0.18, `image-promise` from 0.20 to 0.03, `iphone-inline-video` from 0.28 to 0.20.

