### PR TITLE
Change alias logic to improve realtime even when scoring

### DIFF
--- a/cli/consume.js
+++ b/cli/consume.js
@@ -15,7 +15,7 @@ const log = logger.child({ module: 'cli/consume' });
  * @param {object}  msg      The message
  * @param {Nano}    npmNano  The npm nano instance
  * @param {Nano}    npmsNano The npms nano instance
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} A promise that fulfills when consumed
  */

--- a/cli/scoring.js
+++ b/cli/scoring.js
@@ -20,7 +20,7 @@ const log = logger.child({ module: 'cli/scoring' });
  */
 function waitRemaining(delay, esClient) {
     // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
-    return Promise.resolve(esClient.indices.getAlias({ name: 'npms-read' }))
+    return Promise.resolve(esClient.indices.getAlias({ name: 'npms-current' }))
     .then((response) => {
         const index = Object.keys(response)[0];
         const timestamp = Number(index.replace(/^npms\-/, ''));

--- a/cli/scoring.js
+++ b/cli/scoring.js
@@ -14,12 +14,12 @@ const log = logger.child({ module: 'cli/scoring' });
  * Waits the time needed before running the first cycle.
  *
  * @param {Number}  delay    The delay between each cycle
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} The promise to be waited
  */
 function waitRemaining(delay, esClient) {
-    // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
+    // Need to use Promise.resolve() because Elasticsearch doesn't use the global promise
     return Promise.resolve(esClient.indices.getAlias({ name: 'npms-current' }))
     .then((response) => {
         const index = Object.keys(response)[0];
@@ -40,7 +40,7 @@ function waitRemaining(delay, esClient) {
  *
  * @param {Number}  delay    The delay between each cycle
  * @param {Nano}    npmsNano The npm nano instance
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  */
 function cycle(delay, npmsNano, esClient) {
     const startedAt = Date.now();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,12 +174,12 @@ By looking at the diagram above, you get an idea of how the continuous scoring p
 
 One important detail is that the continuous scoring process creates and maintains two [aliases](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html):
 
-- `npms-read`: Should be used to query the score data
-- `npms-write`: Should be used to write score data
+- `npms-current`: The index with the full data from the last completed scoring process
+- `npms-new`: The index that the current scoring process is writing to
 
 ### Prepare
 
-The prepare step creates a new index and updates the `npms-write` alias to point to that index. It also removes extraneous indices from previous failed cycles (if any).
+The prepare step creates a new index and updates the `npms-new` alias to point to that index. It also removes extraneous indices from previous failed cycles (if any).
 
 ### Aggregate
 
@@ -193,8 +193,8 @@ The module evaluation and aggregation `mean` are normalized ([0, 1]), using the 
 
 ![bezier](./diagrams/bezier.png)
 
-The score data for each module is stored in `Elasticsearch` into the index referenced by the `npms-write` alias.
+The score data for each module are stored in `Elasticsearch` into both `npms-current` and `npms-new` indices.
 
 ### Finalize
 
-The finalize step updates the `npms-read` alias to point to the newly populated index and deletes the previous index.
+The finalize step updates the `npms-current` alias to point to the newly populated index and deletes the `npms-new` alias and previous index.

--- a/lib/observers/realtime.js
+++ b/lib/observers/realtime.js
@@ -30,7 +30,7 @@ class RealtimeObserver {
         this._options = Object.assign({
             concurrency: 25,         // The maximum concurrency in which to call `onModule`
             defaultSeq: null,        // Default seq to be used in the first run (null means from now on)
-            restartDelay: 5000,      // Time to wait before restarting on couchdb errors
+            restartDelay: 5000,      // Time to wait before restarting on CouchDB errors
         }, options);
 
         // Start the thingy!
@@ -115,7 +115,7 @@ class RealtimeObserver {
     }
 
     /**
-     * Fetches the last followed couchdb seq.
+     * Fetches the last followed CouchDB seq.
      *
      * @return {Promise} A promise that resolves to the seq.
      */
@@ -133,7 +133,7 @@ class RealtimeObserver {
     }
 
     /**
-     * Updates the last followed couchdb seq.
+     * Updates the last followed CouchDB seq.
      * If it fails due to a conflict, the last followed seq is refetched.
      *
      * @param {number} seq The sequence
@@ -161,7 +161,7 @@ class RealtimeObserver {
     }
 
     /**
-     * Starts following couchdb changes in realtime.
+     * Starts following CouchDB changes in realtime.
      * Each change is buffered and flushed when appropriate.
      *
      * @return {Promise} A promise that is rejected on error
@@ -189,7 +189,7 @@ class RealtimeObserver {
      * Adds a change to the buffer.
      * The buffer will be flushed if full or after a certain delay.
      *
-     * @param {object} change The couchdb change object
+     * @param {object} change The CouchDB change object
      */
     _addToBuffer(change) {
         // Ignore design documents and other stuff that are not actually modules

--- a/lib/scoring/finalize.js
+++ b/lib/scoring/finalize.js
@@ -4,7 +4,7 @@ const log = logger.child({ module: 'scoring/finalize' });
 
 /**
  * Finalizes the scoring cycle.
- * Updates the `npms-read` alias to point to the new index and removes all the old indices.
+ * Updates the `npms-current` alias to point to the new index and removes all the old indices and aliases.
  *
  * @param {object}  esInfo   The object with the elasticsearch information (returned by prepare())
  * @param {Elastic} esClient The elasticsearch instance
@@ -14,20 +14,23 @@ const log = logger.child({ module: 'scoring/finalize' });
 function finalize(esInfo, esClient) {
     log.info('Finalizing scoring');
 
-    // Update `npms-read` alias to point to the new index
+    // Update `npms-current` alias to point to the new index and removes `npms-new` alias
     return Promise.try(() => {
-        const actions = esInfo.aliases.read.map((index) => {
-            return { remove: { index, alias: 'npms-read' } };
+        // Remove any `npms-current` alias
+        const actions = esInfo.aliases.current.map((index) => {
+            return { remove: { index, alias: 'npms-current' } };
         });
 
-        actions.push({ add: { index: esInfo.newIndex, alias: 'npms-read' } });
+        // Remove `npms-new` and add the new `npms-current` aliases
+        actions.push({ remove: { index: esInfo.newIndex, alias: 'npms-new' } });
+        actions.push({ add: { index: esInfo.newIndex, alias: 'npms-current' } });
 
         return esClient.indices.updateAliases({ body: { actions } })
         .then(() => log.debug({ actions }, 'Updated npms-read alias'));
     })
     // Remove old indices
     .then(() => {
-        const indices = esInfo.aliases.read;
+        const indices = esInfo.aliases.current;
 
         return indices.length && esClient.indices.delete({ index: indices })
         .then(() => log.debug({ indices }, 'Removed old indices pointing to npms-read'));

--- a/lib/scoring/finalize.js
+++ b/lib/scoring/finalize.js
@@ -6,8 +6,8 @@ const log = logger.child({ module: 'scoring/finalize' });
  * Finalizes the scoring cycle.
  * Updates the `npms-current` alias to point to the new index and removes all the old indices and aliases.
  *
- * @param {object}  esInfo   The object with the elasticsearch information (returned by prepare())
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {object}  esInfo   The object with the Elasticsearch information (returned by prepare())
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} A promise that fulfills when done
  */

--- a/lib/scoring/prepare.js
+++ b/lib/scoring/prepare.js
@@ -12,9 +12,9 @@ const log = logger.child({ module: 'scoring/prepare' });
  * Collects information about the current indices and aliases, creates a new index for the
  * scores to be written and updates the `npms-new` alias to point to it.
  *
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
- * @return {Promise} A promise that resolves with the elasticsearch information
+ * @return {Promise} A promise that resolves with the Elasticsearch information
  */
 function prepare(esClient) {
     const esInfo = {};
@@ -47,7 +47,7 @@ function prepare(esClient) {
                 match && esInfo.aliases[match[1]].push(index);
             });
         })
-        .then(() => log.debug({ esInfo }, 'Gathered elasticsearch info..'));
+        .then(() => log.debug({ esInfo }, 'Gathered Elasticsearch info..'));
     })
     // Create a new index in which the scores will be written
     .then(() => {

--- a/lib/scoring/prepare.js
+++ b/lib/scoring/prepare.js
@@ -10,7 +10,7 @@ const log = logger.child({ module: 'scoring/prepare' });
 /**
  * Prepares the start of a scoring cycle.
  * Collects information about the current indices and aliases, creates a new index for the
- * scores to be written and updates the `npms-write` alias to point to it.
+ * scores to be written and updates the `npms-new` alias to point to it.
  *
  * @param {Elastic} esClient The elasticsearch instance
  *
@@ -29,7 +29,7 @@ function prepare(esClient) {
         ])
         .spread((indicesCat, aliasesCat) => {
             esInfo.indices = [];
-            esInfo.aliases = { read: [], write: [] };
+            esInfo.aliases = { current: [], new: [] };
 
             (indicesCat || '').split(/\s*\n\s*/).forEach((lines) => {
                 const split = lines.split(/\s+/);
@@ -42,7 +42,7 @@ function prepare(esClient) {
                 const split = lines.split(/\s+/);
                 const alias = split[0];
                 const index = split[1];
-                const match = alias.match(/^npms\-(write|read)$/);
+                const match = alias.match(/^npms\-(current|new)$/);
 
                 match && esInfo.aliases[match[1]].push(index);
             });
@@ -56,20 +56,22 @@ function prepare(esClient) {
         return esClient.indices.create({ index: esInfo.newIndex, body: esIndexConfig })
         .then(() => log.debug({ index: esInfo.newIndex }, 'Created new index'));
     })
-    // Update the `npms-write` alias to point to the previously created index
+    // Update the `npms-new` alias to point to the previously created index
     .then(() => {
-        const actions = esInfo.aliases.write.map((index) => {
-            return { remove: { index, alias: 'npms-write' } };
+        // Remove any `npms-new` alias
+        const actions = esInfo.aliases.new.map((index) => {
+            return { remove: { index, alias: 'npms-new' } };
         });
 
-        actions.push({ add: { index: esInfo.newIndex, alias: 'npms-write' } });
+        // Add the new `npms-new` alias
+        actions.push({ add: { index: esInfo.newIndex, alias: 'npms-new' } });
 
         return esClient.indices.updateAliases({ body: { actions } })
-        .then(() => log.debug({ actions }, 'Updated npms-write alias'));
+        .then(() => log.debug({ actions }, 'Updated npms-new alias'));
     })
-    // Remove all indices except the ones pointing to `npms-read` (should be only 1)
+    // Remove all indices except the ones pointing to `npms-current` (should be only 1)
     .then(() => {
-        const indices = difference(esInfo.indices, esInfo.aliases.read);
+        const indices = difference(esInfo.indices, esInfo.aliases.current);
 
         return indices.length && esClient.indices.delete({ index: indices })
         .then(() => log.debug({ indices }, 'Removed unnecessary indices'));

--- a/lib/scoring/score.js
+++ b/lib/scoring/score.js
@@ -170,6 +170,55 @@ function buildScore(analysis, aggregation) {
     };
 }
 
+/**
+ * Stores a module score in `npms-current` and `npms-new` indices.
+ *
+ * If none of the indices exist, the operation fails.
+ *
+ * @param {object}  score            The score data
+ * @param {object}  indicesExistence The object from getIndicesExistence()
+ * @param {Elastic} esClient         The elasticsearch instance
+ *
+ * @return {Promise} A promise that fulfills when done
+ */
+function storeScore(score, indicesExistence, esClient) {
+    // Fail if none exist
+    if (!indicesExistence.current && !indicesExistence.new) {
+        return Promise.reject(Object.assign(new Error('Index `npms-current` and `npms-new` are not created'),
+            { code: 'SCORE_INDEX_NOT_FOUND' }));
+    }
+
+    const name = score.module.name;
+
+    return Promise.all([
+        indicesExistence.current && esClient.index({ index: 'npms-current', type: 'module', id: name, body: score })
+        .catch({ status: 404 }, () => {
+            throw Object.assign(new Error('Index `npms-current` was deleted meanwhile'), { code: 'SCORE_INDEX_NOT_FOUND' });
+        }),
+        indicesExistence.new && esClient.index({ index: 'npms-new', type: 'module', id: name, body: score })
+        .catch({ status: 404 }, () => {
+            throw Object.assign(new Error('Index `npms-new` was deleted meanwhile'), { code: 'SCORE_INDEX_NOT_FOUND' });
+        }),
+    ])
+    .then(() => log.trace({ score, indicesExistence }, `Stored score for ${name}`))
+    .return(score);
+}
+
+/**
+ * Checks the existence of `npms-current` and `npms-new` indices.
+ *
+ * @param {Elastic} esClient The elasticsearch instance
+ *
+ * @return {Promise} A promise that fulfills when done
+ */
+function getIndicesExistence(esClient) {
+    return Promise.props({
+        current: esClient.indices.exists({ index: 'npms-current' }),
+        new: esClient.indices.exists({ index: 'npms-new' }),
+    })
+    .tap((existence) => log.trace({ existence }, 'Got indices existence'));
+}
+
 // -------------------------------------------------------------------
 
 /**
@@ -182,11 +231,7 @@ function buildScore(analysis, aggregation) {
  */
 function get(name, esClient) {
     // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
-    return Promise.resolve(esClient.get({
-        index: 'npms-read',
-        type: 'module',
-        id: name,
-    }))
+    return Promise.resolve(esClient.get({ index: 'npms-current', type: 'module', id: name }))
     .get('_source')
     .catch({ status: 404 }, () => {
         throw Object.assign(new Error(`Score for ${name} does not exist`), { code: 'SCORE_NOT_FOUND' });
@@ -196,24 +241,35 @@ function get(name, esClient) {
 /**
  * Removes a module score data.
  *
+ * Removes score data from both `npms-current` and `npms-new` indices.
+ *
  * @param {string} name      The module name
  * @param {Elastic} esClient The elasticsearch instance
  *
  * @return {Promise} The promise that fulfills when done
  */
 function remove(name, esClient) {
-    // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
-    return Promise.resolve(esClient.delete({
-        index: 'npms-write',
-        type: 'module',
-        id: name,
-    }))
-    .catch({ status: 404 }, () => {})
+    // Check the existence of `npms-current` and `npms-new` indices
+    // This was not necessary but since DELETE creates the index if it doesn't exist, we wan't to avoid elasticsearch
+    // spitting  out errors in its logs because we disable these indices auto-creation
+    return getIndicesExistence(esClient)
+    .then((indicesExistence) => {
+        // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
+        return Promise.all([
+            indicesExistence.current && Promise.resolve(esClient.delete({ index: 'npms-current', type: 'module', id: name }))
+            .catch({ status: 404 }, () => {}),  // Just in case..
+            indicesExistence.new && Promise.resolve(esClient.delete({ index: 'npms-new', type: 'module', id: name }))
+            .catch({ status: 404 }, () => {}),  // Just in case..
+        ]);
+    })
     .then(() => log.trace(`Removed score of ${name}`));
 }
 
 /**
  * Saves a module score data.
+ *
+ * Stores score data in `npms-current` and `npms-new` indices.
+ * If none of the indices exist, the operation fails.
  *
  * @param {object} score     The score data
  * @param {Elastic} esClient The elasticsearch instance
@@ -221,19 +277,17 @@ function remove(name, esClient) {
  * @return {Promise} The promise that fulfills when done
  */
 function save(score, esClient) {
-    // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
-    return Promise.resolve(esClient.index({
-        index: 'npms-write',
-        type: 'module',
-        id: score.module.name,
-        body: score,
-    }))
-    .then(() => log.trace({ score }, `Stored score for ${score.module.name}`))
-    .return(score);
+    // Check the existence of `npms-current` and `npms-new` indices
+    return getIndicesExistence(esClient)
+    // Store the score in the indices
+    .then((indicesExistence) => storeScore(score, indicesExistence, esClient));
 }
 
 /**
  * Scores all modules.
+ *
+ * Scores are stored in `npms-current` and `npms-new` indices.
+ * If none of the indices exist, the operation fails.
  *
  * @param {object}  aggregation The most up to date aggregation
  * @param {Nano}    npmsNano The npm nano instance
@@ -242,33 +296,30 @@ function save(score, esClient) {
  * @return {Promise} A promise that fulfills when done
  */
 function all(aggregation, npmsNano, esClient) {
-    log.info({ aggregation }, 'Scoring modules..');
+    // Check the existence of `npms-current` and `npms-new` indices
+    return getIndicesExistence(esClient)
+    // Iterate over all modules and score them!
+    .then((indicesExistence) => {
+        log.info({ indicesExistence, aggregation }, 'Scoring modules..');
 
-    return couchdbIterator(npmsNano, (row) => {
-        row.index && row.index % 10000 === 0 && log.info(`Scored a total of ${row.index} modules`);
+        return couchdbIterator(npmsNano, (row) => {
+            row.index && row.index % 10000 === 0 && log.info(`Scored a total of ${row.index} modules`);
 
-        if (!row.doc) {
-            return;
-        }
+            if (!row.doc) {
+                return;
+            }
 
-        const name = row.id.split('!')[1];
-
-        return save(buildScore(row.doc, aggregation), esClient)
-        .then((score) => {
-            log.trace({ score }, `Scoring of ${name} completed`);
-            return score;
-        }, (err) => {
-            log.error({ err }, `Scoring of of ${name} failed`);
-            throw err;
-        });
-    }, {
-        startkey: 'module!',
-        endkey: 'module!\ufff0',
-        concurrency: 50,
-        limit: 2500,
-        includeDocs: true,
-    })
-    .tap((count) => log.info(`Scoring modules completed, scored a total of ${count} modules`));
+            // Store the score in the indices
+            return storeScore(buildScore(row.doc, aggregation), indicesExistence, esClient);
+        }, {
+            startkey: 'module!',
+            endkey: 'module!\ufff0',
+            concurrency: 50,
+            limit: 2500,
+            includeDocs: true,
+        })
+        .tap((count) => log.info(`Scoring modules completed, scored a total of ${count} modules`));
+    });
 }
 
 /**

--- a/lib/scoring/score.js
+++ b/lib/scoring/score.js
@@ -131,7 +131,7 @@ function scoreMaintenance(maintenance, aggregation) {
 }
 
 /**
- * Calculates and builds the score data to be indexed in elasticsearch.
+ * Calculates and builds the score data to be indexed in Elasticsearch.
  *
  * @param {object}  analysis    The module analysis
  * @param {object}  aggregation The most up to date aggregation
@@ -177,7 +177,7 @@ function buildScore(analysis, aggregation) {
  *
  * @param {object}  score            The score data
  * @param {object}  indicesExistence The object from getIndicesExistence()
- * @param {Elastic} esClient         The elasticsearch instance
+ * @param {Elastic} esClient         The Elasticsearch instance
  *
  * @return {Promise} A promise that fulfills when done
  */
@@ -207,7 +207,11 @@ function storeScore(score, indicesExistence, esClient) {
 /**
  * Checks the existence of `npms-current` and `npms-new` indices.
  *
- * @param {Elastic} esClient The elasticsearch instance
+ * This operation is necessary to avoid calling DELETE and POST which tries to auto-create the index automatically,
+ * but will fail because we explicitly disabled auto-creation. When this happens a lot of errors are outputted to the error log;
+ * we want to avoid that..
+ *
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} A promise that fulfills when done
  */
@@ -225,12 +229,12 @@ function getIndicesExistence(esClient) {
  * Gets a module score data.
  *
  * @param {string} name      The module name
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} The promise that fulfills when done
  */
 function get(name, esClient) {
-    // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
+    // Need to use Promise.resolve() because Elasticsearch doesn't use the global promise
     return Promise.resolve(esClient.get({ index: 'npms-current', type: 'module', id: name }))
     .get('_source')
     .catch({ status: 404 }, () => {
@@ -244,17 +248,15 @@ function get(name, esClient) {
  * Removes score data from both `npms-current` and `npms-new` indices.
  *
  * @param {string} name      The module name
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} The promise that fulfills when done
  */
 function remove(name, esClient) {
     // Check the existence of `npms-current` and `npms-new` indices
-    // This was not necessary but since DELETE creates the index if it doesn't exist, we wan't to avoid elasticsearch
-    // spitting  out errors in its logs because we disable these indices auto-creation
     return getIndicesExistence(esClient)
     .then((indicesExistence) => {
-        // Need to use Promise.resolve() because elasticsearch doesn't use the global promise
+        // Need to use Promise.resolve() because Elasticsearch doesn't use the global promise
         return Promise.all([
             indicesExistence.current && Promise.resolve(esClient.delete({ index: 'npms-current', type: 'module', id: name }))
             .catch({ status: 404 }, () => {}),  // Just in case..
@@ -272,7 +274,7 @@ function remove(name, esClient) {
  * If none of the indices exist, the operation fails.
  *
  * @param {object} score     The score data
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} The promise that fulfills when done
  */
@@ -291,7 +293,7 @@ function save(score, esClient) {
  *
  * @param {object}  aggregation The most up to date aggregation
  * @param {Nano}    npmsNano The npm nano instance
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} A promise that fulfills when done
  */
@@ -323,11 +325,11 @@ function all(aggregation, npmsNano, esClient) {
 }
 
 /**
- * Scores a module, indexing its result in elasticsearch to be searchable.
+ * Scores a module, indexing its result in Elasticsearch to be searchable.
  *
  * @param {objects} analysis The module analysis
  * @param {Nano}    npmsNano The npms nano client instance
- * @param {Elastic} esClient The elasticsearch instance
+ * @param {Elastic} esClient The Elasticsearch instance
  *
  * @return {Promise} The promise that fulfills when done
  */


### PR DESCRIPTION
The previous strategy suffered from a realtime problem, where basically any analysis done while scoring would only be visible when the scoring finishes.
~~It actually is worse than I though: if the scoring gets canceled for some reason, the analysis would be lost!~~ It would be recovered in the next scoring cycle.

//cc @atduarte 

Instructions to deploy:

- [ ] Stop analyzer
- [ ] Update elasticsearch.yml and restart it
- [ ] Deploy
- [ ] Run scoring & wait
- [ ] Deploy npms-api changes
- [ ] Deploy npms-badges changes
- [ ] Remove old npms-read & npms-write aliases
- [ ] Start analyzer