### PR TITLE
No packages lost

### DIFF
--- a/cli/consume.js
+++ b/cli/consume.js
@@ -7,6 +7,12 @@ const score = require('../lib/scoring/score');
 const bootstrap = require('./util/bootstrap');
 const stats = require('./util/stats');
 
+// Need JSON.parse & JSON stringify because of config reserved words
+// See: https://github.com/lorenwest/node-config/issues/223
+const blacklist = JSON.parse(JSON.stringify(config.get('blacklist')));
+const gitRefOverrides = JSON.parse(JSON.stringify(config.get('gitRefOverrides')));
+const githubTokens = config.get('githubTokens');
+
 const log = logger.child({ module: 'cli/consume' });
 
 /**
@@ -23,11 +29,13 @@ function onMessage(msg, npmNano, npmsNano, esClient) {
     const name = msg.data;
 
     // Check if this package is blacklisted
-    const blacklisted = config.get('blacklist')[name];
+    const blacklisted = blacklist[name];
 
     if (blacklisted) {
-        log.info({ reason: blacklisted }, `Package ${name} is blacklisted`);
-        return Promise.resolve();
+        const err = Object.assign(new Error(`Package ${name} is blacklisted`), { code: 'BLACKLISTED', unrecoverable: true });
+
+        return onFailedAnalysis(name, err, npmsNano, esClient)
+        .catch(() => {});
     }
 
     log.info(`Processing package ${name}`);
@@ -43,17 +51,27 @@ function onMessage(msg, npmNano, npmsNano, esClient) {
 
         // If not, analyze it! :D
         return analyze(name, npmNano, npmsNano, {
-            githubTokens: config.get('githubTokens'),
-            gitRefOverrides: config.get('gitRefOverrides'),
+            githubTokens,
+            gitRefOverrides,
             waitRateLimit: true,
             rev: analysis && analysis._rev,
         })
         // Score it to get a "real-time" feeling, ignoring any errors
         .then((analysis) => score(analysis, npmsNano, esClient).catch(() => {}))
-        .catch({ code: 'PACKAGE_NOT_FOUND' }, (err) => score.remove(name, esClient).finally(() => { throw err; }))
+        .catch({ code: 'PACKAGE_NOT_FOUND' }, () => score.remove(name, esClient))
         // Ignore unrecoverable errors, so that these are not re-queued
-        .catch({ unrecoverable: true }, () => {});
+        .catch({ unrecoverable: true }, (err) => {
+            return onFailedAnalysis(name, err, npmsNano, esClient)
+            .catch(() => {});
+        });
     });
+}
+
+function onFailedAnalysis(name, err, npmsNano, esClient) {
+    // Save the failed analysis, by generating an empty analysis object with the associated error
+    return analyze.saveFailed(name, err, npmsNano)
+    // Score it to get a "real-time" feeling, ignoring any errors
+    .then((analysis) => score(analysis, npmsNano, esClient).catch(() => {}));
 }
 
 // ----------------------------------------------------------------------------
@@ -87,12 +105,15 @@ module.exports.handler = (argv) => {
         stats.process();
         stats.queue(queue);
         stats.progress(npmNano, npmsNano);
-        stats.tokens(config.get('githubTokens'), 'github');
+        stats.tokens(githubTokens, 'github');
 
         // Clean old packages from the download directory
         return analyze.cleanTmpDir()
         // Start consuming
-        .then(() => queue.consume((message) => onMessage(message, npmNano, npmsNano, esClient), { concurrency: argv.concurrency }));
+        .then(() => queue.consume((message) => onMessage(message, npmNano, npmsNano, esClient), {
+            concurrency: argv.concurrency,
+            onRetriesExceeded: (message, err) => onFailedAnalysis(message.data, err, npmsNano, esClient),
+        }));
     })
     .done();
 };

--- a/cli/consume.js
+++ b/cli/consume.js
@@ -12,7 +12,6 @@ const stats = require('./util/stats');
 const blacklist = JSON.parse(JSON.stringify(config.get('blacklist')));
 const gitRefOverrides = JSON.parse(JSON.stringify(config.get('gitRefOverrides')));
 const githubTokens = config.get('githubTokens');
-
 const log = logger.child({ module: 'cli/consume' });
 
 /**

--- a/cli/scoring.js
+++ b/cli/scoring.js
@@ -23,7 +23,7 @@ function waitRemaining(delay, esClient) {
     return Promise.resolve(esClient.indices.getAlias({ name: 'npms-current' }))
     .then((response) => {
         const index = Object.keys(response)[0];
-        const timestamp = Number(index.replace(/^npms\-/, ''));
+        const timestamp = Number(index.replace(/^npms-/, ''));
         const wait = timestamp ? Math.max(0, timestamp + delay - Date.now()) : 0;
         const waitStr = humanizeDuration(Math.round(wait / 1000) * 1000, { largest: 2 });
 

--- a/cli/tasks/clean-extraneous.js
+++ b/cli/tasks/clean-extraneous.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const config = require('config');
 const difference = require('lodash/difference');
 const stats = require('../util/stats');
 const bootstrap = require('../util/bootstrap');
 
-const blacklisted = config.get('blacklist');
 const log = logger.child({ module: 'cli/clean-extraneous' });
 
 /**
@@ -20,7 +18,7 @@ function fetchNpmPackages(npmNano) {
     .then((response) => {
         return response.rows
         .map((row) => row.id)
-        .filter((id) => id.indexOf('_design/') !== 0 && !blacklisted[id]);
+        .filter((id) => id.indexOf('_design/') !== 0);
     });
 }
 

--- a/cli/tasks/clean-extraneous.js
+++ b/cli/tasks/clean-extraneous.js
@@ -88,7 +88,7 @@ module.exports.handler = (argv) => {
 
             return Promise.map(extraneousPackages, (name) => {
                 count += 1;
-                count && count % 100 === 0 && log.info(`Removed ${count} packages`);
+                count % 100 === 0 && log.info(`Removed ${count} packages`);
 
                 const key = `package!${name}`;
 

--- a/cli/tasks/enqueue-missing.js
+++ b/cli/tasks/enqueue-missing.js
@@ -89,7 +89,7 @@ module.exports.handler = (argv) => {
 
             return Promise.map(missingPackages, (name) => {
                 count += 1;
-                count && count % 1000 === 0 && log.info(`Enqueued ${count} packages`);
+                count % 1000 === 0 && log.info(`Enqueued ${count} packages`);
                 return queue.push(name);
             }, { concurrency: 15 })
             .then(() => log.info('Missing packages were enqueued!'));

--- a/cli/tasks/enqueue-missing.js
+++ b/cli/tasks/enqueue-missing.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const config = require('config');
 const difference = require('lodash/difference');
 const bootstrap = require('../util/bootstrap');
 const stats = require('../util/stats');
 
-const blacklisted = config.get('blacklist');
 const log = logger.child({ module: 'cli/enqueue-missing' });
 
 /**
@@ -20,7 +18,7 @@ function fetchNpmPackages(npmNano) {
     .then((response) => {
         return response.rows
         .map((row) => row.id)
-        .filter((id) => id.indexOf('_design/') !== 0 && !blacklisted[id]);
+        .filter((id) => id.indexOf('_design/') !== 0);
     });
 }
 

--- a/cli/tasks/enqueue-view.js
+++ b/cli/tasks/enqueue-view.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const assert = require('assert');
-const config = require('config');
 const bootstrap = require('../util/bootstrap');
 const stats = require('../util/stats');
 
-const blacklisted = config.get('blacklist');
 const log = logger.child({ module: 'cli/enqueue-view' });
 
 /**
@@ -22,8 +20,7 @@ function fetchView(view, npmNano) {
     return npmNano.viewAsync(split[0], split[1])
     .then((response) => {
         return response.rows
-        .map((row) => row.key.replace(/^package!/, ''))
-        .filter((id) => !blacklisted[id]);
+        .map((row) => row.key.replace(/^package!/, ''));
     });
 }
 
@@ -46,7 +43,7 @@ name (may be prefixed with `package!`)')
     })
 
     .check((argv) => {
-        assert(/^[a-z0-9_\-]+\/[a-z0-9_\-]+$/.test(argv._[2]), 'The view argument must match the following format: <design-doc/view-name>');
+        assert(/^[a-z0-9_-]+\/[a-z0-9_-]+$/.test(argv._[2]), 'The view argument must match the following format: <design-doc/view-name>');
         return true;
     });
 };

--- a/cli/util/stats/progress.js
+++ b/cli/util/stats/progress.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const config = require('config');
 const pino = require('pino');
 
 const log = logger.child({ module: 'stats/progress' });
@@ -19,7 +18,6 @@ function statProgress(npmNano, npmsNano) {
         return;
     }
 
-    const blacklistCount = Object.keys(config.blacklist).length;
     let pending = false;
 
     setInterval(() => {
@@ -31,7 +29,7 @@ function statProgress(npmNano, npmsNano) {
         pending = true;
 
         Promise.props({
-            npmDocsCount: npmNano.infoAsync().then((res) => res.doc_count - blacklistCount),
+            npmDocsCount: npmNano.infoAsync().then((res) => res.doc_count),
             npmDesignDocsCount: npmNano.listAsync({ startkey: '_design/', endkey: '_design0' }).then((res) => res.rows.length),
             npmsPackagesCount: npmsNano.viewAsync('npms-analyzer', 'packages-evaluation', { reduce: true })
             .then((res) => res.rows[0].value),

--- a/config/couchdb/npms-analyzer.json
+++ b/config/couchdb/npms-analyzer.json
@@ -1,13 +1,13 @@
 {
-   "_id": "_design/npms-analyzer",
-   "language": "javascript",
-   "views": {
-       "packages-evaluation": {
-           "map": "function (doc) {\n    if (doc._id.indexOf('package!') === 0) {\n        emit(doc._id.split('!')[1], doc.evaluation);\n    }\n}",
-           "reduce": "_count"
-       },
-       "packages-stale": {
-           "map": "function (doc) {\n    if (doc._id.indexOf('package!') === 0) {\n        emit([Date.parse(doc.finishedAt), doc._id.split('!')[1]]);\n    }\n}"
-       }
-   }
+    "_id": "_design/npms-analyzer",
+    "language": "javascript",
+    "views": {
+        "packages-evaluation": {
+            "map": "function (doc) {\n    if (doc._id.indexOf('package!') === 0) {\n        emit(doc._id.split('!')[1], doc.evaluation);\n    }\n}",
+            "reduce": "_count"
+        },
+        "packages-stale": {
+            "map": "function (doc) {\n    if (doc._id.indexOf('package!') === 0) {\n        if (doc.error) {\n        emit(['failed', Date.parse(doc.error.caughtAt), doc._id.split('!')[1]]);\n        } else {\n            emit(['normal', Date.parse(doc.finishedAt), doc._id.split('!')[1]]);\n        }\n    }\n}"
+        }
+    }
 }

--- a/config/default.json5
+++ b/config/default.json5
@@ -22,13 +22,11 @@
 
     // List of packages that will be ignored by the CLI consume command (analysis process)
     blacklist: {
-        'yourmom': 'Huge tar bomb',
-        'tone-police': 'Registry crashes while downloading',
-        'isit322-swu': 'Registry crashes while downloading',
-        'zachtestproject1': 'Registry returns 500 internal',
-        'zachtestproject2': 'Registry returns 500 internal',
-        'zachtestproject3': 'Registry returns 500 internal',
-        'zachtestproject4': 'Registry returns 500 internal',
+        'hownpm': 'Invalid version: 1.01',
+        'zachtestproject1': 'Test project that makes registry return 500 internal',
+        'zachtestproject2': 'Test project that makes registry return 500 internal',
+        'zachtestproject3': 'Test project that makes registry return 500 internal',
+        'zachtestproject4': 'Test project that makes registry return 500 internal',
     },
 
     // List of download target overrides to be used when downloading

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -45,3 +45,7 @@ This project uses [config](https://www.npmjs.com/package/config) for configurati
   - `action.auto_create_index: -npms-current,-npms-new,+*``
   - `script.engine.groovy.inline.search: on`
   - `script.engine.groovy.inline.update: on`
+
+  ## Crontab
+
+  If you plan to run this in production, you should add `$ npms-analyzer tasks enqueue-missing` and `npms-analyzer tasks clean-extraneous` to crontab. These tasks ensure that, in case of errors, the `npms` packages are in sync with the packages from the `npm` registry.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,4 +48,4 @@ This project uses [config](https://www.npmjs.com/package/config) for configurati
 
   ## Crontab
 
-  If you plan to run this in production, you should add `$ npms-analyzer tasks enqueue-missing` and `npms-analyzer tasks clean-extraneous` to crontab. These tasks ensure that, in case of errors, the `npms` packages are in sync with the packages from the `npm` registry.
+  If you plan to run this in production, you should add `$ npms-analyzer tasks enqueue-missing` and `$ npms-analyzer tasks clean-extraneous` to crontab. These tasks ensure that, in case of errors, the `npms` packages are in sync with the packages from the `npm` registry.

--- a/lib/analyze/collect/index.js
+++ b/lib/analyze/collect/index.js
@@ -57,6 +57,19 @@ function checkRepositoryOwnership(data, packageJson, downloaded, npmNano) {
 // ----------------------------------------------------------------------------
 
 /**
+ * Generates an empty collected data.
+ *
+ * @param  {name} name The package name
+ *
+ * @return {object} The empty collected data
+ */
+function empty(name) {
+    return {
+        metadata: collectors.metadata.empty(name),
+    };
+}
+
+/**
  * Runs all the collectors.
  *
  * @param {string} data        The package data
@@ -90,4 +103,5 @@ function collect(data, packageJson, downloaded, npmNano, options) {
 }
 
 module.exports = collect;
+module.exports.empty = empty;
 module.exports.collectors = collectors;

--- a/lib/analyze/collect/metadata.js
+++ b/lib/analyze/collect/metadata.js
@@ -238,6 +238,23 @@ function extractMaintainers(data, packageJson) {
 // ----------------------------------------------------------------------------
 
 /**
+ * Generates an empty metadata objet.
+ *
+ * @param  {name} name The package name
+ *
+ * @return {object} The empty collected data
+ */
+function empty(name) {
+    return {
+        name,
+        version: '0.0.0',
+        links: {
+            npm: `https://www.npmjs.com/package/${encodeURIComponent(name)}`,
+        },
+    };
+}
+
+/**
  * Runs the metadata analyzer.
  *
  * @param {object} data        The package data
@@ -291,3 +308,4 @@ function metadata(data, packageJson) {
 }
 
 module.exports = metadata;
+module.exports.empty = empty;

--- a/lib/analyze/evaluate/maintenance.js
+++ b/lib/analyze/evaluate/maintenance.js
@@ -19,6 +19,10 @@ const log = logger.child({ module: 'evaluate/maintenance' });
 function evaluateReleasesFrequency(collected) {
     const releases = collected.metadata.releases;
 
+    if (!releases) {
+        return 0;
+    }
+
     const range30 = find(releases, (range) => moment.utc(range.to).diff(range.from, 'd') === 30);
     const range180 = find(releases, (range) => moment.utc(range.to).diff(range.from, 'd') === 180);
     const range365 = find(releases, (range) => moment.utc(range.to).diff(range.from, 'd') === 365);

--- a/lib/analyze/evaluate/popularity.js
+++ b/lib/analyze/evaluate/popularity.js
@@ -11,7 +11,12 @@ const find = require('lodash/find');
  * @return {number} The monthly downloads mean (from 0 to Infinity)
  */
 function evaluateDownloadsCount(collected) {
-    const downloads = collected.npm.downloads;
+    const downloads = collected.npm && collected.npm.downloads;
+
+    if (!downloads) {
+        return 0;
+    }
+
     const index = downloads.findIndex((range) => moment.utc(range.to).diff(range.from, 'd') === 90);
 
     if (index === -1) {
@@ -32,7 +37,11 @@ function evaluateDownloadsCount(collected) {
  * @return {number} The downloads acceleration (from -Infinity to Infinity)
  */
 function evaluateDownloadsAcceleration(collected) {
-    const downloads = collected.npm.downloads;
+    const downloads = collected.npm && collected.npm.downloads;
+
+    if (!downloads) {
+        return 0;
+    }
 
     const range30 = find(downloads, (range) => moment.utc(range.to).diff(range.from, 'd') === 30);
     const range90 = find(downloads, (range) => moment.utc(range.to).diff(range.from, 'd') === 90);
@@ -61,10 +70,10 @@ function evaluateDownloadsAcceleration(collected) {
  * @return {number} The community interest (from 0 to Infinity)
  */
 function evaluateCommunityInterest(collected) {
-    const starsCount = ((collected.github && collected.github.starsCount) || 0) + collected.npm.starsCount;
-    const forksCount = (collected.github && collected.github.forksCount) || 0;
-    const subscribersCount = (collected.github && collected.github.subscribersCount) || 0;
-    const contributorsCount = (collected.github && collected.github.contributors || []).length;
+    const starsCount = (collected.github ? collected.github.starsCount : 0) + (collected.npm ? collected.npm.starsCount : 0);
+    const forksCount = collected.github ? collected.github.forksCount : 0;
+    const subscribersCount = collected.github ? collected.github.subscribersCount : 0;
+    const contributorsCount = collected.github ? (collected.github.contributors || []).length : 0;
 
     return starsCount + forksCount + subscribersCount + contributorsCount;
 }
@@ -83,7 +92,7 @@ function popularity(collected) {
         communityInterest: evaluateCommunityInterest(collected),
         downloadsCount: evaluateDownloadsCount(collected),
         downloadsAcceleration: evaluateDownloadsAcceleration(collected),
-        dependentsCount: collected.npm.dependentsCount,
+        dependentsCount: collected.npm ? collected.npm.dependentsCount : 0,
     };
 }
 

--- a/lib/analyze/index.js
+++ b/lib/analyze/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const promiseRetry = require('promise-retry');
+const serializeError = require('serialize-error');
 const collect = require('./collect');
 const evaluate = require('./evaluate');
 const download = require('./download');
@@ -91,6 +92,36 @@ function save(analysis, npmsNano) {
 }
 
 /**
+ * Saves a failed analysis of a package.
+ *
+ * @param {string} name     The package name
+ * @param {Error}  err      The analysis error
+ * @param {Nano}   npmsNano The npms nano client instance
+ *
+ * @return {Promise} The promise for the saved analysis document
+ */
+function saveFailed(name, err, npmsNano) {
+    return get(name, npmsNano)
+    .catch({ code: 'ANALYSIS_NOT_FOUND' }, () => ({}))
+    .tap((analysis) => {
+        analysis.error = serializeError(err);
+        analysis.error.caughtAt = (new Date()).toISOString();
+        analysis.startedAt = analysis.startedAt || (new Date()).toISOString();
+        analysis.finishedAt = analysis.finishedAt || (new Date()).toISOString();
+        analysis.collected = analysis.collected || collect.empty(name);
+        analysis.evaluation = analysis.evaluation || evaluate(analysis.collected);
+    })
+    .then((analysis) => save(analysis, npmsNano))
+    .then((analysis) => {
+        log.debug({ analysis }, `Saved failed analysis of ${name}`);
+        return analysis;
+    }, (err) => {
+        log.error({ err }, `Error while saving failed analysis of ${name}`);
+        throw err;
+    });
+}
+
+/**
  * Analyses a package, running the collectors & evaluators and then saving the result.
  *
  * @param {string} name      The package name
@@ -164,5 +195,6 @@ function analyze(name, npmNano, npmsNano, options) {
 module.exports = analyze;
 module.exports.get = get;
 module.exports.save = save;
+module.exports.saveFailed = saveFailed;
 module.exports.remove = remove;
 module.exports.cleanTmpDir = download.cleanTmpDir;

--- a/lib/observers/stale.js
+++ b/lib/observers/stale.js
@@ -100,7 +100,7 @@ class StaleObserver {
         // Check for normal stale packages
         this._checkByType('failed')
         // Check for stale packages which analysis have failed
-        // .then(() => this._checkByType('normal'))
+        .then(() => this._checkByType('normal'))
         // Schedule the next check
         .then(this._ignoreIfStopped(() => {
             this._checkTimeout = setTimeout(() => {

--- a/lib/observers/stale.js
+++ b/lib/observers/stale.js
@@ -27,9 +27,12 @@ class StaleObserver {
         this._npmsNano = npmsNano;
         this._onPackage = onPackage;
         this._options = Object.assign({
-            concurrency: 25,                           // The maximum concurrency in which to call `onPackage`
-            staleThreshold: 15 * 24 * 60 * 60 * 1000,  // Threshold in which a package is considered stale (defaults to 15d)
-            checkDelay: 30 * 60 * 1000,                // Time to wait before checking for stale packages (defaults to 30m)
+            concurrency: 25,                       // The maximum concurrency in which to call `onPackage`
+            staleThreshold: {
+                normal: 15 * 24 * 60 * 60 * 1000,  // Threshold in which a package analysis is considered stale (defaults to 15d)
+                failed: 1000,                      // Threshold in which a failed package analysis is considered stale (defaults to 12h)
+            },
+            checkDelay: 30 * 60 * 1000,            // Time to wait before checking for stale package analysis (defaults to 30m)
         }, options);
 
         // Start the thingy!
@@ -94,39 +97,10 @@ class StaleObserver {
      * Schedules a new check once done.
      */
     _check() {
-        log.debug('Looking for stale packages..');
-
-        // Fetch stale packages by querying the `packages-stale` view
-        couchdbIterator.bulk(this._npmsNano, 'npms-analyzer/packages-stale', this._ignoreIfStopped((rows) => {
-            const names = rows.filter((row) => row.doc).map((row) => row.doc.collected.metadata.name);
-
-            log.debug(`Got ${rows.length} packages that are considered stale, filtering..`);
-
-            // Filter names to only contain the ones that have new versions
-            return this._filterNotNotified(names)
-            // Notify packages, updating the observer doc for successful ones
-            .spread(this._ignoreIfStopped((filteredNames, bulkUpdate) => {
-                const ignoredCount = names.length - filteredNames.length;
-                const successfulNames = [];
-
-                filteredNames && log.debug(`Notifying ${filteredNames.length} stale packages`);
-                ignoredCount && log.info(`Ignored ${ignoredCount} packages because they were already notified`);
-
-                return Promise.map(filteredNames, this._ignoreIfStopped((name) => {
-                    return this._onPackage(name)
-                    .then(() => { successfulNames.push(name); });
-                }))
-                .finally(this._ignoreIfStopped(() => bulkUpdate(successfulNames)));
-            }));
-        }), {
-            startkey: [0, null],
-            endkey: [Date.now() - this._options.staleThreshold, '\ufff0'],
-            includeDocs: true,
-            bulkSize: this._options.concurrency,
-        })
-        .catch(this._ignoreIfStopped((err) => {
-            log.error({ err }, 'Stale observer failed when notifying packages');
-        }))
+        // Check for normal stale packages
+        this._checkByType('failed')
+        // Check for stale packages which analysis have failed
+        // .then(() => this._checkByType('normal'))
         // Schedule the next check
         .then(this._ignoreIfStopped(() => {
             this._checkTimeout = setTimeout(() => {
@@ -137,16 +111,60 @@ class StaleObserver {
     }
 
     /**
+     * Searches the database, looking for stale packages of a specific type.
+     *
+     * @param {string} type The staleness type (normal or failed)
+     *
+     * @return {Promise} A promise that fullfills when done
+     */
+    _checkByType(type) {
+        log.debug(`Looking for stale packages (${type})..`);
+
+        // Fetch stale packages by querying the `packages-stale` view
+        return couchdbIterator.bulk(this._npmsNano, 'npms-analyzer/packages-stale', this._ignoreIfStopped((rows) => {
+            const names = rows.filter((row) => row.doc).map((row) => row.doc.collected.metadata.name);
+
+            log.debug(`Got ${rows.length} packages that are considered stale (${type}), filtering..`);
+
+            // Filter names to only contain the ones that have new versions
+            return this._filterNotNotified(names, type)
+            // Notify packages, updating the observer doc for successful ones
+            .spread(this._ignoreIfStopped((filteredNames, bulkUpdate) => {
+                const ignoredCount = names.length - filteredNames.length;
+                const successfulNames = [];
+
+                filteredNames && log.debug(`Notifying ${filteredNames.length} stale packages (${type})`);
+                ignoredCount && log.info(`Ignored ${ignoredCount} stale packages (${type}) because they were already notified`);
+
+                return Promise.map(filteredNames, this._ignoreIfStopped((name) => {
+                    return this._onPackage(name)
+                    .then(() => { successfulNames.push(name); });
+                }))
+                .finally(this._ignoreIfStopped(() => bulkUpdate(successfulNames)));
+            }));
+        }), {
+            startkey: [type, 0, null],
+            endkey: [type, Date.now() - this._options.staleThreshold[type], '\ufff0'],
+            includeDocs: true,
+            bulkSize: this._options.concurrency,
+        })
+        .catch(this._ignoreIfStopped((err) => {
+            log.error({ err }, `Stale observer failed when notifying stale packages (${type})`);
+        }));
+    }
+
+    /**
      * Filters packages that were not yet notified.
      *
-     * It might take some time for a packageto be analyzed. Having that said, we must ensure
+     * It might take some time for a package to be analyzed. Having that said, we must ensure
      * that packages that were previously notified are filtered to avoid repetition.
      *
-     * @param {array} names The package names
+     * @param {array}  names The package names
+     * @param {string} type  The stale type (normal or failed)
      *
      * @return {Promise} A promise that resolves with [filteredNames, bulkUpdate]
      */
-    _filterNotNotified(names) {
+    _filterNotNotified(names, type) {
         return this._npmsNano.fetchAsync({ keys: names.map((key) => `observer!package!${key}`) })
         .get('rows')
         .then(this._ignoreIfStopped((observerRows) => {
@@ -156,7 +174,7 @@ class StaleObserver {
             const filteredNames = names.filter((name, index) => {
                 const notifiedAt = get(observerRows[index], 'doc.stale.notifiedAt');
 
-                if (notifiedAt && Date.now() - Date.parse(notifiedAt) <= this._options.staleThreshold) {
+                if (notifiedAt && Date.now() - Date.parse(notifiedAt) <= this._options.staleThreshold[type]) {
                     return false;
                 }
 
@@ -179,8 +197,8 @@ class StaleObserver {
     }
 }
 
-function realtime(npmsAddr, onPackage, options) {
+function stale(npmsAddr, onPackage, options) {
     return new StaleObserver(npmsAddr, onPackage, options);
 }
 
-module.exports = realtime;
+module.exports = stale;

--- a/lib/observers/stale.js
+++ b/lib/observers/stale.js
@@ -30,7 +30,7 @@ class StaleObserver {
             concurrency: 25,                       // The maximum concurrency in which to call `onPackage`
             staleThreshold: {
                 normal: 15 * 24 * 60 * 60 * 1000,  // Threshold in which a package analysis is considered stale (defaults to 15d)
-                failed: 1000,                      // Threshold in which a failed package analysis is considered stale (defaults to 12h)
+                failed: 12 * 60 * 60 * 1000,       // Threshold in which a failed package analysis is considered stale (defaults to 12h)
             },
             checkDelay: 30 * 60 * 1000,            // Time to wait before checking for stale package analysis (defaults to 30m)
         }, options);
@@ -98,9 +98,9 @@ class StaleObserver {
      */
     _check() {
         // Check for normal stale packages
-        this._checkByType('failed')
+        this._checkType('failed')
         // Check for stale packages which analysis have failed
-        .then(() => this._checkByType('normal'))
+        .then(() => this._checkType('normal'))
         // Schedule the next check
         .then(this._ignoreIfStopped(() => {
             this._checkTimeout = setTimeout(() => {
@@ -117,7 +117,7 @@ class StaleObserver {
      *
      * @return {Promise} A promise that fullfills when done
      */
-    _checkByType(type) {
+    _checkType(type) {
         log.debug(`Looking for stale packages (${type})..`);
 
         // Fetch stale packages by querying the `packages-stale` view
@@ -130,10 +130,11 @@ class StaleObserver {
             return this._filterNotNotified(names, type)
             // Notify packages, updating the observer doc for successful ones
             .spread(this._ignoreIfStopped((filteredNames, bulkUpdate) => {
-                const ignoredCount = names.length - filteredNames.length;
+                const filteredCount = filteredNames.length;
+                const ignoredCount = names.length - filteredCount;
                 const successfulNames = [];
 
-                filteredNames && log.debug(`Notifying ${filteredNames.length} stale packages (${type})`);
+                filteredCount && log.debug(`Notifying ${filteredNames.length} stale packages (${type})`);
                 ignoredCount && log.info(`Ignored ${ignoredCount} stale packages (${type}) because they were already notified`);
 
                 return Promise.map(filteredNames, this._ignoreIfStopped((name) => {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -173,12 +173,12 @@ class Queue extends EventEmitter {
         this._connectPromise = Promise.resolve(this._reconnectDelayPromise)
         // Connect to RabbitMQ!
         .then(() => {
-            return amqp.connect(this._addr, this._options.socket)
+            return Promise.resolve(amqp.connect(this._addr, this._options.socket))
             .tap((connection) => { this._connection = connection; });
         })
         // Configure channel & queue
         .then((connection) => {
-            return connection.createConfirmChannel()
+            return Promise.resolve(connection.createConfirmChannel())
             .tap((channel) => { this._channel = channel; })
             .then((channel) => channel.assertQueue(this._name, {
                 durable: true,
@@ -294,7 +294,7 @@ class Queue extends EventEmitter {
         this._consumer = consumer;
         this._channel.prefetch(this._consumer.concurrency);
 
-        return this._channel.consume(this._name, (queueMessage) => {
+        return Promise.resolve(this._channel.consume(this._name, (queueMessage) => {
             // According to http://www.squaremobius.net/amqp.node/channel_api.html#channel_consume, if RabbitMQ
             // cancels this consumer then `queueMessage` will be null
             if (!queueMessage) {
@@ -315,7 +315,7 @@ class Queue extends EventEmitter {
                 this._handleConsumerError(err, message, queueMessage);
             })
             .done();
-        })
+        }))
         .then(() => {
             log.info('Consumer was registered successfully, will now receive messages..');
         }, (err) => {
@@ -364,7 +364,7 @@ class Queue extends EventEmitter {
         // Did we reach the max allowed retries?
         if (message.retryCount >= this._consumer.maxRetries) {
             log.fatal({ err, message }, `Failed to consume message, NOT re-queueing after ${message.retryCount} failed attempts`);
-            Promise.resolve(this._consumer.onRetriesExceeded && this._consumer.onRetriesExceeded(message, err))
+            Promise.try(() => this._consumer.onRetriesExceeded && this._consumer.onRetriesExceeded(message, err))
             .finally(() => this._channel.nack(queueMessage, false, false));
             return;
         }
@@ -394,15 +394,7 @@ class Queue extends EventEmitter {
     _sendToQueue(message) {
         const content = new Buffer(JSON.stringify(message));
 
-        return new Promise((resolve, reject) => {
-            this._channel.sendToQueue(this._name, content, { persistent: true, priority: message.priority }, (err) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
-        });
+        return Promise.resolve(this._channel.sendToQueue(this._name, content, { persistent: true, priority: message.priority }));
     }
 
     /**

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -101,8 +101,9 @@ class Queue extends EventEmitter {
         }
 
         options = Object.assign({
-            concurrency: 1,  // Concurrency at which `fn` will be run
-            maxRetries: 5,   // Maximum number of retries allowed for the same message
+            concurrency: 1,           // Concurrency at which `fn` will be run
+            maxRetries: 5,            // Maximum number of retries allowed for the same message
+            onRetriesExceeded: null,  // Called when all retries where exhausted when consuming the message
         }, options);
 
         const consumer = Object.assign({ fn }, options);
@@ -363,7 +364,8 @@ class Queue extends EventEmitter {
         // Did we reach the max allowed retries?
         if (message.retryCount >= this._consumer.maxRetries) {
             log.fatal({ err, message }, `Failed to consume message, NOT re-queueing after ${message.retryCount} failed attempts`);
-            this._channel.nack(queueMessage, false, false);
+            Promise.resolve(this._consumer.onRetriesExceeded && this._consumer.onRetriesExceeded(message, err))
+            .finally(() => this._channel.nack(queueMessage, false, false));
             return;
         }
 

--- a/lib/scoring/prepare.js
+++ b/lib/scoring/prepare.js
@@ -35,14 +35,14 @@ function prepare(esClient) {
                 const split = lines.split(/\s+/);
                 const index = split[0];
 
-                /^npms\-\d+$/.test(index) && esInfo.indices.push(index);
+                /^npms-\d+$/.test(index) && esInfo.indices.push(index);
             });
 
             (aliasesCat || '').split(/\s*\n\s*/).forEach((lines) => {
                 const split = lines.split(/\s+/);
                 const alias = split[0];
                 const index = split[1];
-                const match = alias.match(/^npms\-(current|new)$/);
+                const match = alias.match(/^npms-(current|new)$/);
 
                 match && esInfo.aliases[match[1]].push(index);
             });

--- a/lib/scoring/score.js
+++ b/lib/scoring/score.js
@@ -154,7 +154,7 @@ function buildScore(analysis, aggregation) {
             'name', 'version', 'description', 'keywords', 'date', 'links',
             'author', 'publisher', 'maintainers',
         ]),
-        flags: {
+        flags: analysis.error ? null : {
             deprecated: collected.metadata.deprecated,
             insecure: collected.source && collected.source.vulnerabilities ? collected.source.vulnerabilities.length : null,
             unstable: semver.lt(collected.metadata.version, '1.0.0', true) ? true : null,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "promise-retry": "^1.0.1",
     "require-directory": "^2.1.1",
     "semver": "^5.1.0",
+    "serialize-error": "^2.0.0",
     "spdx": "^0.5.0",
     "spdx-correct": "^1.0.2",
     "token-dealer": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "André Cruz <amdfcruz@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "amqplib": "^0.4.0",
+    "amqplib": "^0.5.0",
     "bignumber.js": "^2.3.0",
     "bluebird": "^3.1.1",
     "camelcase-keys": "^4.0.0",

--- a/test/fixtures/analyze/download/recorded/npm/ff4470aede5dba39b4736419dda38443.headers
+++ b/test/fixtures/analyze/download/recorded/npm/ff4470aede5dba39b4736419dda38443.headers
@@ -1,0 +1,13 @@
+{
+  "timeout": true,
+  "time": 0,
+  "url": "https://api.github.com:443/repos/strongloop-forks/strong-fork-syslog/stats/contributors",
+  "request": {
+    "method": "GET",
+    "headers": {
+      "user-agent": "got/6.6.0 (https://github.com/sindresorhus/got)",
+      "accept-encoding": "gzip,deflate",
+      "accept": "application/vnd.github.v3+json"
+    }
+  }
+}

--- a/test/spec/analyze/collect/index.js
+++ b/test/spec/analyze/collect/index.js
@@ -277,4 +277,8 @@ describe('index', () => {
             .finally(() => sepia.disable());
         });
     });
+
+    describe('empty', () => {
+        it('should generate an empty collected object');
+    });
 });

--- a/test/spec/analyze/collect/metadata.js
+++ b/test/spec/analyze/collect/metadata.js
@@ -236,4 +236,8 @@ describe('metadata', () => {
             });
         });
     });
+
+    describe('empty', () => {
+        it('should generate an empty metadata object');
+    });
 });

--- a/test/spec/analyze/download/index.js
+++ b/test/spec/analyze/download/index.js
@@ -112,7 +112,7 @@ describe('index', () => {
         .then(() => {
             expect(betrayed.invoked).to.equal(1);
             expect(tmpDir.indexOf(`${os.tmpdir()}/npms-analyzer/cross-spawn-`)).to.equal(0);
-            expect(tmpDir).to.match(/\-[a-z0-9]+$/);
+            expect(tmpDir).to.match(/-[a-z0-9]+$/);
         })
         .finally(() => betrayed.restore());
     });


### PR DESCRIPTION
This PR ensures that the number of packages in `npms` is always in sync with the ones from `npm` registry.

Before: If 5 consecutive errors happened while analyzing a package, it was simply discarded and no analysis data was stored. This means that this package was simply not searchable.
Now: If 5 consecutive errors happen, an "empty" analysis is created and the package is evaluated and scored as usual. While this package has a 0 score, at least it can be searchable from both main search and suggestions.

`npms-www` and `npms-cli` projects were already updated to handle packages that only contain `name`, `version` and `links.npm` props.

Also:

- Fix linting errors
- Fix some minor bugs that I found while testing
- Upgrade amqlib version

Deploy:

- [ ] Stop the analyzer
- [ ] Update the [design doc](https://github.com/npms-io/npms-analyzer/blob/master/config/couchdb/npms-analyzer.json) and make sure it is indexed by querying it once via futon
- [ ] Deploy
- [ ] Run `./cli.js tasks enqueue-missing` and `./cli.js tasks clean-extraneous`; also add these two commands to crontab