### PR TITLE
Add options.maxFiles to all downloaders

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,7 +11,7 @@ This project uses [config](https://www.npmjs.com/package/config) for configurati
 ## General utilities
 
 - `git` must be installed and available in the `$PATH`.
-- GNU coreutils (`rm`, `mkdir`, `chmod`) must be available.
+- GNU coreutils (`rm`, `mkdir`, `chmod`, `wc`) must be available.
 - `tar` or `bsdtar` must be available (BSD version is preferred.. on Debian install with `$ aptitude install bsdtar`)
 - Install the `pino` CLI to prettify logging output by running `$ npm install -g pino`
 

--- a/lib/analyze/download/git.js
+++ b/lib/analyze/download/git.js
@@ -4,6 +4,7 @@ const urlLib = require('url');
 const exec = require('../util/exec');
 const hostedGitInfo = require('../util/hostedGitInfo');
 const mergePackageJson = require('./util/mergePackageJson');
+const assertFilesCount = require('./util/assertFilesCount');
 
 const log = logger.child({ module: 'download/git' });
 
@@ -113,6 +114,7 @@ function git(packageJson, options) {
     options = Object.assign({
         refOverrides: null,  // An hash of ref overrides to be used
         maxTime: 600000,     // Max allowed download time (10m)
+        maxFiles: 16000,     // Max allowed files to download (using git ls-remote)
     }, options);
 
     const refOverride = options.refOverrides ? options.refOverrides[packageJson.name] : undefined;
@@ -127,11 +129,12 @@ function git(packageJson, options) {
         const ref = refOverride || packageJson.gitHead || null;
 
         return download(url, ref, tmpDir, options)
+        .tap(() => assertFilesCount(tmpDir, options.maxFiles))
         .then((downloadedRef) => Promise.all([downloadedRef, mergePackageJson(packageJson, tmpDir, { preferDownloaded: !!refOverride })]))
-        .spread((downloadedRef, downloadedPackageJson) => ({
+        .spread((downloadedRef, mergedPackageJson) => ({
             downloader: 'git',
             dir: tmpDir,
-            packageJson: downloadedPackageJson,
+            packageJson: mergedPackageJson,
             gitRef: downloadedRef,
         }));
     };

--- a/lib/analyze/download/git.js
+++ b/lib/analyze/download/git.js
@@ -114,7 +114,7 @@ function git(packageJson, options) {
     options = Object.assign({
         refOverrides: null,  // An hash of ref overrides to be used
         maxTime: 600000,     // Max allowed download time (10m)
-        maxFiles: 16000,     // Max allowed files to download (using git ls-remote)
+        maxFiles: 16000,     // Max allowed files to download
     }, options);
 
     const refOverride = options.refOverrides ? options.refOverrides[packageJson.name] : undefined;

--- a/lib/analyze/download/github.js
+++ b/lib/analyze/download/github.js
@@ -58,7 +58,7 @@ function download(shorthand, ref, tmpDir, options) {
 
                 if (contentLength > options.maxSize) {
                     request.abort();
-                    reject(Object.assign(new Error(`Tarball is too large (~${Math.round(contentLength / 1024 / 1024)}MB)`), {
+                    reject(Object.assign(new Error(`${shorthand} tarball is too large (~${Math.round(contentLength / 1024 / 1024)}MB)`), {
                         unrecoverable: true,
                     }));
                 }
@@ -84,7 +84,7 @@ function download(shorthand, ref, tmpDir, options) {
     // Extract tarball
     .then(() => {
         log.debug({ tarballFile }, `Successfully downloaded ${shorthand} tarball, will now extract ..`);
-        return untar(tarballFile);
+        return untar(tarballFile, { maxFiles: options.maxFiles });
     })
     // Clear out the ref if any error occurred; also delete downloaded archive if any
     .catch((err) => {
@@ -142,6 +142,7 @@ function github(packageJson, options) {
         refOverrides: null,    // An hash of ref overrides to be used
         waitRateLimit: false,  // True to wait if rate limit for all tokens were exceeded
         maxSize: 262144000,    // Max allowed download size (250MB)
+        maxFiles: 16000,       // Max allowed files to download (extract)
     }, options);
 
     const refOverride = options.refOverrides ? options.refOverrides[packageJson.name] : undefined;
@@ -157,10 +158,10 @@ function github(packageJson, options) {
 
         return download(shorthand, ref, tmpDir, options)
         .then((downloadedRef) => Promise.all([downloadedRef, mergePackageJson(packageJson, tmpDir, { preferDownloaded: !!refOverride })]))
-        .spread((downloadedRef, downloadedPackageJson) => ({
+        .spread((downloadedRef, mergedPackageJson) => ({
             downloader: 'github',
             dir: tmpDir,
-            packageJson: downloadedPackageJson,
+            packageJson: mergedPackageJson,
             gitRef: downloadedRef,
         }));
     };

--- a/lib/analyze/download/index.js
+++ b/lib/analyze/download/index.js
@@ -58,9 +58,9 @@ function download(packageJson, options) {
     let downloadFn;
 
     options = Object.assign({
-        githubTokens: null,    // The GitHub API tokens to use
-        gitRefOverrides: null, // An hash of ref overrides to be used
-        waitRateLimit: false,  // True to wait if rate limit for all tokens were exceeded
+        githubTokens: null,    // The GitHub API tokens to use (applicable to the GitHub downloader)
+        gitRefOverrides: null, // An hash of ref overrides to be used (applicable to Git and GitHub downloader)
+        waitRateLimit: false,  // True to wait if rate limit for all tokens were exceeded (applicable to GitHub downloader)
     }, options);
 
     downloadersOrder.some((downloader) => {

--- a/lib/analyze/download/index.js
+++ b/lib/analyze/download/index.js
@@ -58,9 +58,9 @@ function download(packageJson, options) {
     let downloadFn;
 
     options = Object.assign({
-        githubTokens: null,    // The GitHub API tokens to use (applicable to the GitHub downloader)
-        gitRefOverrides: null, // An hash of ref overrides to be used (applicable to Git and GitHub downloader)
-        waitRateLimit: false,  // True to wait if rate limit for all tokens were exceeded (applicable to GitHub downloader)
+        githubTokens: null,    // The GitHub API tokens to use
+        gitRefOverrides: null, // An hash of ref overrides to be used
+        waitRateLimit: false,  // True to wait if rate limit for all tokens were exceeded
     }, options);
 
     downloadersOrder.some((downloader) => {

--- a/lib/analyze/download/npm.js
+++ b/lib/analyze/download/npm.js
@@ -49,7 +49,7 @@ function download(target, url, tmpDir, options) {
     // Extract tarball
     .then(() => {
         log.debug({ tarballFile }, `Successfully downloaded ${target} tarball, will now extract ..`);
-        return untar(tarballFile);
+        return untar(tarballFile, { maxFiles: options.maxFiles });
     })
     // Check if the repository does not exist
     .catch((err) => err.statusCode === 404, (err) => {
@@ -78,6 +78,7 @@ function download(target, url, tmpDir, options) {
 function npm(packageJson, options) {
     options = Object.assign({
         maxSize: 262144000,  // Max allowed download size (250MB)
+        maxFiles: 16000,     // Max allowed files to download (extract)
     }, options);
 
     return (tmpDir) => {
@@ -93,7 +94,11 @@ function npm(packageJson, options) {
             log.warn(`No tarball url for ${target}`);
         })
         .then(() => mergePackageJson(packageJson, tmpDir, { preferDownloaded: false }))
-        .then((downloadedPackageJson) => ({ downloader: 'npm', dir: tmpDir, packageJson: downloadedPackageJson }));
+        .then((mergedPackageJson) => ({
+            downloader: 'npm',
+            dir: tmpDir,
+            packageJson: mergedPackageJson,
+        }));
     };
 }
 

--- a/lib/analyze/download/util/assertFilesCount.js
+++ b/lib/analyze/download/util/assertFilesCount.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const exec = require('../../util/exec');
+
+/**
+ * Asserts that the number of files in a directory is within a certain threshold.
+ *
+ * This should be used by downloaders if they can't pre-calculate the number of files
+ * without actually starting populating a directory with files.
+ *
+ * @param {string} dir     The dir
+ * @param {number} maxFiles The total number of files
+ *
+ * @return {Promise} A promise that fulfills when done
+ */
+function assertFilesCount(dir, maxFiles) {
+    return exec(exec.escape`find ${dir} | wc -l`)
+    .spread((stdout) => parseInt(stdout, 10))
+    .tap((filesCount) => {
+        if (isNaN(filesCount)) {
+            throw Object.assign(new Error('Unable to retrieve the number of files within the directory'),
+                { unrecoverable: true, dir });
+        }
+
+        if (filesCount > maxFiles) {
+            throw Object.assign(new Error('Directory has too many files'), { unrecoverable: true, dir });
+        }
+    });
+}
+
+module.exports = assertFilesCount;

--- a/lib/analyze/download/util/untar.js
+++ b/lib/analyze/download/util/untar.js
@@ -8,7 +8,6 @@ const exec = require('../../util/exec');
 // Prefer bsdtar over the installed tar.. bsdtar is more benevolent when dealing with certain errors
 // See: http://comments.gmane.org/gmane.comp.gnu.mingw.msys/4816
 const tarExec = (() => { try { return which.sync('bsdtar'); } catch (err) { return 'tar'; } })();
-const log = logger.child({ module: 'util/untar' });
 
 /**
  * Asserts that the number of files in the tar archive is below a certain threshold.
@@ -68,7 +67,8 @@ filter() {
 
 set -o pipefail
 { decompress 2>&1 1>&3 | filter 1>&2; } 3>&1
-`, { shell: '/bin/bash' });
+`, { shell: '/bin/bash' })
+    .then(() => exec(exec.escape`chmod -R 0777 ${destDir}`));
 }
 
 // --------------------------------------------------
@@ -91,14 +91,15 @@ function untar(file, options) {
     return assertFilesCount(file, options.maxFiles)
     // Proceed with decompressing
     .then(() => decompress(file, destDir))
+    // Delete tar file
+    .then(() => unlink(file))
     // Ignore invalid tar files.. sometimes services respond with JSON
     // e.g.: http://registry.npmjs.org/n-pubsub/-/n-pubsub-1.0.0.tgz
     // e.g.: testing233 package, that somehow was able to set dist to http://example.com
-    .catch((err) => /unrecognized archive format|does not look like a tar archive|not in gzip format/i.test(err.stderr), (err) => {
-        log.warn({ tarballFiles: file, err }, 'Malformed tarball, ignoring..');
+    .catch((err) => /unrecognized archive format|does not look like a tar archive|not in gzip format|unknown compression format/i.test(err.stderr), () => {
+        throw Object.assign(new Error('Tarball is malformed'), { tarballFile: file });
     })
-    .then(() => unlink(file))
-    .then(() => exec(exec.escape`chmod -R 0777 ${destDir}`));
+    .return(destDir);
 }
 
 module.exports = untar;

--- a/lib/analyze/download/util/untar.js
+++ b/lib/analyze/download/util/untar.js
@@ -19,7 +19,20 @@ const log = logger.child({ module: 'util/untar' });
  * @return {Promise} A promise that fulfills when done
  */
 function assertFilesCount(file, maxFiles) {
-    return exec(exec.escape`tar -ztf ${file} | wc -l`)
+    // Ignore "unknown extended header XX" because there might be a lot of them, e.g.: pickles2-contents-editor
+    // This only happens when using gnu tar, see: http://lee.greens.io/blog/2014/05/06/fix-tar-errors-on-os-x/
+    // e.g.: http://registry.npmjs.org/pickles2-contents-editor/-/pickles2-contents-editor-2.0.0-alpha.1.tgz
+    return exec(exec.escape`
+listFiles() {
+    ${tarExec} -ztf ${file}
+}
+filter() {
+    (grep -v "unknown extended header"; exit 0)
+}
+
+set -o pipefail
+{ listFiles 2>&1 1>&3 | filter 1>&2; } 3>&1 | wc -l
+`, { shell: '/bin/bash' })
     .spread((stdout) => parseInt(stdout, 10))
     .tap((filesCount) => {
         if (isNaN(filesCount)) {
@@ -31,6 +44,31 @@ function assertFilesCount(file, maxFiles) {
             throw Object.assign(new Error('Tarball has too many files'), { unrecoverable: true, tarballFile: file });
         }
     });
+}
+
+/**
+ * Decompresses a tar file to a directory.
+ *
+ * @param {string} file    The file path
+ * @param {string} destDir The destination directory
+ *
+ * @return {Promise} A promise that fulfills when done
+ */
+function decompress(file, destDir) {
+    // Ignore "unknown extended header XX" because there might be a lot of them, e.g.: pickles2-contents-editor
+    // This only happens when using gnu tar, see: http://lee.greens.io/blog/2014/05/06/fix-tar-errors-on-os-x/
+    // e.g.: http://registry.npmjs.org/pickles2-contents-editor/-/pickles2-contents-editor-2.0.0-alpha.1.tgz
+    return exec(exec.escape`
+decompress() {
+    ${tarExec} -xf ${file} -C ${destDir} --strip-components=1
+}
+filter() {
+    (grep -v "unknown extended header"; exit 0)
+}
+
+set -o pipefail
+{ decompress 2>&1 1>&3 | filter 1>&2; } 3>&1
+`, { shell: '/bin/bash' });
 }
 
 // --------------------------------------------------
@@ -47,29 +85,20 @@ function assertFilesCount(file, maxFiles) {
 function untar(file, options) {
     options = Object.assign({ maxFiles: 16000 }, options);
 
+    const destDir = path.dirname(file);
+
     // Check the number of files
     return assertFilesCount(file, options.maxFiles)
     // Proceed with decompressing
-    .then(() => {
-        const destDir = path.dirname(file);
-
-        // Ignore "unknown extended header XX" because there might be a lot of them, e.g.: pickles2-contents-editor
-        // This only happens when using gnu tar, see: http://lee.greens.io/blog/2014/05/06/fix-tar-errors-on-os-x/
-        // e.g.: http://registry.npmjs.org/pickles2-contents-editor/-/pickles2-contents-editor-2.0.0-alpha.1.tgz
-        return exec(exec.escape`
-    set -o pipefail;
-    ${tarExec} -xf ${file} -C ${destDir} --strip-components=1 2>&1 |
-    (grep -v "unknown extended header" 1>&2; exit 0)
-    `, { shell: '/bin/bash' })
-        // Ignore invalid tar files.. sometimes services respond with JSON
-        // e.g.: http://registry.npmjs.org/n-pubsub/-/n-pubsub-1.0.0.tgz
-        // e.g.: testing233 package, that somehow was able to set dist to http://example.com
-        .catch((err) => /unrecognized archive format|does not look like a tar archive|not in gzip format/i.test(err.stderr), (err) => {
-            log.warn({ tarballFiles: file, err }, 'Malformed tarball, ignoring..');
-        })
-        .then(() => unlink(file))
-        .then(() => exec(exec.escape`chmod -R 0777 ${destDir}`));
-    });
+    .then(() => decompress(file, destDir))
+    // Ignore invalid tar files.. sometimes services respond with JSON
+    // e.g.: http://registry.npmjs.org/n-pubsub/-/n-pubsub-1.0.0.tgz
+    // e.g.: testing233 package, that somehow was able to set dist to http://example.com
+    .catch((err) => /unrecognized archive format|does not look like a tar archive|not in gzip format/i.test(err.stderr), (err) => {
+        log.warn({ tarballFiles: file, err }, 'Malformed tarball, ignoring..');
+    })
+    .then(() => unlink(file))
+    .then(() => exec(exec.escape`chmod -R 0777 ${destDir}`));
 }
 
 module.exports = untar;

--- a/lib/analyze/download/util/untar.js
+++ b/lib/analyze/download/util/untar.js
@@ -11,32 +11,65 @@ const tarExec = (() => { try { return which.sync('bsdtar'); } catch (err) { retu
 const log = logger.child({ module: 'util/untar' });
 
 /**
- * Small utility to untar a file.
- * Malformed tar errors are ignored.
+ * Asserts that the number of files in the tar archive is below a certain threshold.
  *
- * @param {string} file The file path
+ * @param {string} file     The file path
+ * @param {number} maxFiles The total number of files
  *
  * @return {Promise} A promise that fulfills when done
  */
-function untar(file) {
-    const destDir = path.dirname(file);
+function assertFilesCount(file, maxFiles) {
+    return exec(exec.escape`tar -ztf ${file} | wc -l`)
+    .spread((stdout) => parseInt(stdout, 10))
+    .tap((filesCount) => {
+        if (isNaN(filesCount)) {
+            throw Object.assign(new Error('Unable to retrieve the number of files within the tarball'),
+                { unrecoverable: true, tarballFile: file });
+        }
 
-    // Ignore "unknown extended header XX" because there might be a lot of them, e.g.: pickles2-contents-editor
-    // This only happens when using gnu tar, see: http://lee.greens.io/blog/2014/05/06/fix-tar-errors-on-os-x/
-    // e.g.: http://registry.npmjs.org/pickles2-contents-editor/-/pickles2-contents-editor-2.0.0-alpha.1.tgz
-    return exec(exec.escape`
-set -o pipefail;
-${tarExec} -xf ${file} -C ${destDir} --strip-components=1 2>&1 |
-(grep -v "unknown extended header" 1>&2; exit 0)
-`, { shell: '/bin/bash' })
-    // Ignore invalid tar files.. sometimes services respond with JSON
-    // e.g.: http://registry.npmjs.org/n-pubsub/-/n-pubsub-1.0.0.tgz
-    // e.g.: testing233 package, that somehow was able to set dist to http://example.com
-    .catch((err) => /unrecognized archive format|does not look like a tar archive|not in gzip format/i.test(err.stderr), (err) => {
-        log.warn({ file, err }, 'Malformed archive file, ignoring..');
-    })
-    .then(() => unlink(file))
-    .then(() => exec(exec.escape`chmod -R 0777 ${destDir}`));
+        if (filesCount > maxFiles) {
+            throw Object.assign(new Error('Tarball has too many files'), { unrecoverable: true, tarballFile: file });
+        }
+    });
+}
+
+// --------------------------------------------------
+
+/**
+ * Small utility to untar a file.
+ * Malformed tar errors are ignored.
+ *
+ * @param {string} file      The file path
+ * @param {object} [options] he options; read below to get to know each available option
+ *
+ * @return {Promise} A promise that fulfills when done
+ */
+function untar(file, options) {
+    options = Object.assign({ maxFiles: 16000 }, options);
+
+    // Check the number of files
+    return assertFilesCount(file, options.maxFiles)
+    // Proceed with decompressing
+    .then(() => {
+        const destDir = path.dirname(file);
+
+        // Ignore "unknown extended header XX" because there might be a lot of them, e.g.: pickles2-contents-editor
+        // This only happens when using gnu tar, see: http://lee.greens.io/blog/2014/05/06/fix-tar-errors-on-os-x/
+        // e.g.: http://registry.npmjs.org/pickles2-contents-editor/-/pickles2-contents-editor-2.0.0-alpha.1.tgz
+        return exec(exec.escape`
+    set -o pipefail;
+    ${tarExec} -xf ${file} -C ${destDir} --strip-components=1 2>&1 |
+    (grep -v "unknown extended header" 1>&2; exit 0)
+    `, { shell: '/bin/bash' })
+        // Ignore invalid tar files.. sometimes services respond with JSON
+        // e.g.: http://registry.npmjs.org/n-pubsub/-/n-pubsub-1.0.0.tgz
+        // e.g.: testing233 package, that somehow was able to set dist to http://example.com
+        .catch((err) => /unrecognized archive format|does not look like a tar archive|not in gzip format/i.test(err.stderr), (err) => {
+            log.warn({ tarballFiles: file, err }, 'Malformed tarball, ignoring..');
+        })
+        .then(() => unlink(file))
+        .then(() => exec(exec.escape`chmod -R 0777 ${destDir}`));
+    });
 }
 
 module.exports = untar;

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint": "^3.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^3.0.1",
+    "mock-require": "^1.3.0",
     "nock": "^9.0.0",
     "sepia": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "betray": "^1.3.0",
     "chai": "^3.5.0",
     "chronokinesis": "^1.1.0",
+    "clear-require": "^1.0.1",
     "coveralls": "^2.11.6",
     "eslint": "^3.0.0",
     "istanbul": "^0.4.2",

--- a/test/spec/analyze/collect/github.js
+++ b/test/spec/analyze/collect/github.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const expect = require('chai').expect;
-const sepia = require('sepia');
+const sepia = require(`${process.cwd()}/test/util/sepia`);
 const betray = require('betray');
-const nock = require('nock');
 const chronokinesis = require('chronokinesis');
 const loadJsonFile = require('load-json-file');
 const packageJsonFromData = require(`${process.cwd()}/lib/analyze/util/packageJsonFromData`);
@@ -83,22 +82,22 @@ describe('github', () => {
 
             sepia.enable();
 
-            nock('https://api.github.com', { allowUnmocked: true })
+            sepia.nock('https://api.github.com', { allowUnmocked: true })
             .get('/repos/IndigoUnited/node-cross-spawn/stats/commit_activity')
             .reply(202, () => {
-                nock.cleanAll();
+                sepia.nock.cleanAll();
 
                 return [];
             });
 
             return github(packageJsonFromData('cross-spawn', data), {})
             .then((collected) => {
-                expect(nock.isDone()).to.equal(true);
+                expect(sepia.nock.isDone()).to.equal(true);
                 expect(collected).to.eql(expected);
             })
             .finally(() => {
+                sepia.nock.cleanAll();
                 sepia.disable();
-                nock.cleanAll();
             });
         });
 
@@ -130,7 +129,7 @@ describe('github', () => {
             const betrayed = betray(logger.children['collect/github'], 'info');
 
             // Can't use sepia because of https://github.com/linkedin/sepia/issues/15
-            nock('https://api.github.com')
+            sepia.nock('https://api.github.com')
             .persist()
             .get(/.*/)
             .reply(400);
@@ -146,7 +145,7 @@ describe('github', () => {
             })
             .finally(() => {
                 betrayed.restore();
-                nock.cleanAll();
+                sepia.nock.cleanAll();
             });
         });
 

--- a/test/spec/analyze/collect/index.js
+++ b/test/spec/analyze/collect/index.js
@@ -5,7 +5,7 @@ const loadJsonFile = require('load-json-file');
 const nano = require('nano');
 const expect = require('chai').expect;
 const betray = require('betray');
-const sepia = require('sepia');
+const sepia = require(`${process.cwd()}/test/util/sepia`);
 const collect = require(`${process.cwd()}/lib/analyze/collect`);
 const packageJsonFromData = require(`${process.cwd()}/lib/analyze/util/packageJsonFromData`);
 

--- a/test/spec/analyze/collect/metadata.js
+++ b/test/spec/analyze/collect/metadata.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const sepia = require('sepia');
+const sepia = require(`${process.cwd()}/test/util/sepia`);
 const chronokinesis = require('chronokinesis');
 const loadJsonFile = require('load-json-file');
 const packageJsonFromData = require(`${process.cwd()}/lib/analyze/util/packageJsonFromData`);

--- a/test/spec/analyze/collect/npm.js
+++ b/test/spec/analyze/collect/npm.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const sepia = require('sepia');
-const nock = require('nock');
+const sepia = require(`${process.cwd()}/test/util/sepia`);
 const betray = require('betray');
 const chronokinesis = require('chronokinesis');
 const nano = require('nano');
@@ -43,7 +42,7 @@ describe('npm', () => {
     });
 
     it('should handle 200 OK error responses from api.npmjs.org', () => {
-        nock('https://api.npmjs.org')
+        sepia.nock('https://api.npmjs.org')
         .get((path) => path.indexOf('/downloads/range/') === 0)
         .reply(200, { error: 'foo' });
 
@@ -53,14 +52,14 @@ describe('npm', () => {
         .then(() => {
             throw new Error('Expected to fail');
         }, (err) => {
-            expect(nock.isDone()).to.equal(true);
+            expect(sepia.nock.isDone()).to.equal(true);
             expect(err.message).to.equal('foo');
         })
-        .finally(() => nock.cleanAll());
+        .finally(() => sepia.nock.cleanAll());
     });
 
     it('should handle `no stats yet` error from api.npmjs.org', () => {
-        nock('https://api.npmjs.org')
+        sepia.nock('https://api.npmjs.org')
         .get((path) => path.indexOf('/downloads/range/') === 0)
         .reply(200, { error: 'no stats for this package' });
 
@@ -70,7 +69,7 @@ describe('npm', () => {
         .then((collected) => {
             collected.downloads.forEach((download) => expect(download.count).to.equal(0));
         })
-        .finally(() => nock.cleanAll());
+        .finally(() => sepia.nock.cleanAll());
     });
 
     it('should retry on network errors');

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ if (process.cwd() !== path.join(__dirname, '..')) {
 
 // Configure
 require('../lib/configure');
+require('./util/sepia');
 logger.level = 'fatal';
 
 // Auto-load tests

--- a/test/util/sepia.js
+++ b/test/util/sepia.js
@@ -1,29 +1,42 @@
 'use strict';
 
+/**
+ * This file adds .enable() and .disable() to sepia.
+ * Additionally any usage of nock must use sepia.nock so that interoperability with sepia works without issues.
+ */
+
+const glob = require('glob');
 const http = require('http');
 const https = require('https');
+const clearRequire = require('clear-require');
 
+// Grab original requests
 const originalRequests = { http: http.request, https: https.request };
+
+// Grab sepia requests + nock (used when enabled)
 const sepia = require('sepia');
+const enabledNock = require('nock');
 const sepiaRequests = { http: http.request, https: https.request };
 
-/**
- * Turns sepia on.
- */
+// Grab standalone requests + nock (used when disabled)
+http.request = originalRequests.http;
+https.request = originalRequests.https;
+clearRequire('nock');
+glob.sync('**/*.js', { cwd: `${process.cwd()}/node_modules/nock/lib` }).forEach((file) => clearRequire(`nock/lib/${file}`));
+const disabledNock = require('nock');
+const nockedRequests = { http: http.request, https: https.request };
+
 function enable() {
     http.request = sepiaRequests.http;
     https.request = sepiaRequests.https;
+    sepia.nock = enabledNock;
 }
 
-/**
- * Turns sepia off.
- */
 function disable() {
-    http.request = originalRequests.http;
-    https.request = originalRequests.https;
+    http.request = nockedRequests.http;
+    https.request = nockedRequests.https;
+    sepia.nock = disabledNock;
 }
-
-disable();
 
 sepia.enable = enable;
 sepia.disable = disable;

--- a/test/util/sepia.js
+++ b/test/util/sepia.js
@@ -27,8 +27,8 @@ glob.sync('**/*.js', { cwd: `${process.cwd()}/node_modules/nock/lib` }).forEach(
 const disabledNock = require('nock');
 const nockedRequests = { http: http.request, https: https.request };
 
-// Mock the timed-out module used by got() to avoid timeouts being triggered
-// becase socket 'connect' event is never fired when using sepia/nock
+// Mock the timed-out module used by got() to avoid timeouts being triggered:  the socket 'connect' event
+// is never fired when using sepia/nock
 // See: https://github.com/floatdrop/timed-out/blob/bdc812346570a0ed4e6d7d5fdc668e2feb72f239/index.js#L21
 mockRequire('timed-out', (req) => req);
 

--- a/test/util/sepia.js
+++ b/test/util/sepia.js
@@ -9,6 +9,7 @@ const glob = require('glob');
 const http = require('http');
 const https = require('https');
 const clearRequire = require('clear-require');
+const mockRequire = require('mock-require');
 
 // Grab original requests
 const originalRequests = { http: http.request, https: https.request };
@@ -25,6 +26,11 @@ clearRequire('nock');
 glob.sync('**/*.js', { cwd: `${process.cwd()}/node_modules/nock/lib` }).forEach((file) => clearRequire(`nock/lib/${file}`));
 const disabledNock = require('nock');
 const nockedRequests = { http: http.request, https: https.request };
+
+// Mock the timed-out module used by got() to avoid timeouts being triggered
+// becase socket 'connect' event is never fired when using sepia/nock
+// See: https://github.com/floatdrop/timed-out/blob/bdc812346570a0ed4e6d7d5fdc668e2feb72f239/index.js#L21
+mockRequire('timed-out', (req) => req);
 
 function enable() {
     http.request = sepiaRequests.http;


### PR DESCRIPTION
This prevents packages with huge amounts of files from being analyzed. This was causing a lot of RAM and disk space usage.

All changes:

- Added `options.maxFiles` too all downloaders
- Throw on malformed archives instead of ignoring (better behavior now that we don't lose any package)
- Changed some minor variable/function names
- Fixed tests when using GNU tar
- Fixed tests failing sporadically

@bcoe Note that `bsdtar` is preferred over `tar` (GNU) because it's more resilient to errors. Install with `$ apt-get install bsdtar` on Debian.