### PR TITLE
fix: handle undefined packageJson.repository.url

### DIFF
--- a/lib/analyze/util/normalizePackageJson.js
+++ b/lib/analyze/util/normalizePackageJson.js
@@ -47,7 +47,7 @@ function normalizePackageJson(name, packageJson, options) {
     // Remove duplicate .git.git until it gets fixed on normalize-package-data
     // See: https://github.com/npm/normalize-package-data/issues/84
     if (packageJson.repository) {
-        packageJson.repository.url = packageJson.repository.url.replace(/\.git\.git$/i, '.git');
+        packageJson.repository.url = packageJson.repository.url ? packageJson.repository.url.replace(/\.git\.git$/i, '.git') : packageJson.repository.url;
     }
 
     return packageJson;


### PR DESCRIPTION
@satazor can't wait for the `.git.git` issue to be fixed upstream so we can nuke this.