### PR TITLE
chore: fix eslint-disable comment

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -30,7 +30,7 @@ logger[pino.symbols.setLevelSym] = wrap(logger[pino.symbols.setLevelSym], functi
         forIn(logger.children, (child) => { child.level = level; });
     }
 });
-/* eslint-disable no-invalid-this */
+/* eslint-enable no-invalid-this */
 
 // Make some restrictions on the usage of .child()
 logger.child = wrap(logger.child, (createChild, bindings) => {


### PR DESCRIPTION
Re-enable the ESLint rule `no-invalid-this` instead of disabling it again.