### PR TITLE
feat: allow customizable extraction limits

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -32,4 +32,11 @@
 
     // Github tokens to be used by token-dealer
     githubTokens: [],
+
+    // Bailout limits for package analysis
+    analysisLimits: {
+        maxSize: 262144000, // Max allowed download size (250MB) - 1024 * 1024 * 250
+        maxTime: 600000,    // Max allowed download time (10m) - 1000 * 60 * 10
+        maxFiles: 64000     // Max allowed files to download
+    }
 }

--- a/lib/analyze/download/git.js
+++ b/lib/analyze/download/git.js
@@ -6,6 +6,7 @@ const hostedGitInfo = require('../util/hostedGitInfo');
 const findPackageDir = require('./util/findPackageDir');
 const mergePackageJson = require('./util/mergePackageJson');
 const assertFilesCount = require('./util/assertFilesCount');
+const analysisLimits = require('config').analysisLimits;
 
 const log = logger.child({ module: 'download/git' });
 
@@ -113,10 +114,7 @@ function git(packageJson, options) {
         return null;
     }
 
-    options = Object.assign({
-        maxTime: 600000, // Max allowed download time (10m)
-        maxFiles: 32000, // Max allowed files to download
-    }, options);
+    options = Object.assign({}, analysisLimits, options);
 
     return (tmpDir) => {
         const url = getCloneUrl(gitInfo);

--- a/lib/analyze/download/github.js
+++ b/lib/analyze/download/github.js
@@ -9,6 +9,7 @@ const findPackageDir = require('./util/findPackageDir');
 const gotRetry = require('../util/gotRetry');
 const exec = require('../util/exec');
 const mergePackageJson = require('./util/mergePackageJson');
+const analysisLimits = require('config').analysisLimits;
 
 const log = logger.child({ module: 'download/github' });
 const unavailableStatusCodes = [404, 400, 403, 451]; // 404 - not found; 400 - invalid repo name; 403/451 - dmca takedown
@@ -149,9 +150,7 @@ function github(packageJson, options) {
     options = Object.assign({
         tokens: null, // The GitHub API tokens to use
         waitRateLimit: false, // True to wait if rate limit for all tokens were exceeded
-        maxSize: 262144000, // Max allowed download size (250MB)
-        maxFiles: 32000, // Max allowed files to download (extract)
-    }, options);
+    }, analysisLimits, options);
 
     return (tmpDir) => {
         const shorthand = `${gitInfo.user}/${gitInfo.project}`;

--- a/lib/analyze/download/npm.js
+++ b/lib/analyze/download/npm.js
@@ -6,6 +6,7 @@ const untar = require('./util/untar');
 const gotRetry = require('../util/gotRetry');
 const exec = require('../util/exec');
 const mergePackageJson = require('./util/mergePackageJson');
+const analysisLimits = require('config').analysisLimits;
 
 const log = logger.child({ module: 'download/npm' });
 
@@ -78,10 +79,7 @@ function download(target, url, tmpDir, options) {
  * @returns {Function} The download function or null.
  */
 function npm(packageJson, options) {
-    options = Object.assign({
-        maxSize: 262144000, // Max allowed download size (250MB)
-        maxFiles: 32000, // Max allowed files to download (extract)
-    }, options);
+    options = Object.assign({}, analysisLimits, options);
 
     return (tmpDir) => {
         const url = packageJson.dist && packageJson.dist.tarball;


### PR DESCRIPTION
The hard-coded download size limit causes several extremely large (but popular) packages to fail the analysis process, such as [typescript](https://www.npmjs.com/search?q=typescript). Compare with [typescript on npms.io](https://npms.io/search?q=typescript) which shows an old version.

This PR  increases the limit to stop this failure, and also extracts the limits into external config so that they can be changed again more easily in the future if required.